### PR TITLE
Carousel Compatibility Fix

### DIFF
--- a/templates/t04.css
+++ b/templates/t04.css
@@ -46,6 +46,7 @@ body {
   top: 0;
   left: 0;
   z-index: -1;
+  margin: 0 auto;
 }
 .naturewrapper .natureback, .naturewrapper .naturetransition {
   width: 100%;


### PR DESCRIPTION
Fixes the nature wrapper for me on Mac Safari. Only one line, and it doesn't seem to break anything with the site.